### PR TITLE
docs: update build docker image command

### DIFF
--- a/microservices/microservices.md
+++ b/microservices/microservices.md
@@ -323,19 +323,19 @@ cd  ~/github/mastering-microservices/notification
 
 ```bash
 cd  ~/github/mastering-microservices/gateway
-./gradlew -Pprod bootWar buildDocker -x test
+./gradlew -Pprod bootJar jibDockerBuild -x test
 docker images | grep gateway
 
 cd  ~/github/mastering-microservices/productorder
-./gradlew -Pprod bootWar buildDocker -x test
+./gradlew -Pprod bootJar jibDockerBuild -x test
 docker images | grep productorder
 
 cd  ~/github/mastering-microservices/invoice
-./gradlew -Pprod bootWar buildDocker -x test
+./gradlew -Pprod bootJar jibDockerBuild -x test
 docker images | grep invoice
 
 cd  ~/github/mastering-microservices/notification
-./gradlew -Pprod bootWar buildDocker -x test
+./gradlew -Pprod bootJar jibDockerBuild -x test
 docker images | grep notification
 ```
 


### PR DESCRIPTION
Hello @donsez !
Thank you for this in depth tutorial. 

The command: `./gradlew -Pprod bootWar buildDocker -x test` dont work anymore.

I found in their official documentation a new way to package and build the docker image.
https://www.jhipster.tech/docker-compose/#3